### PR TITLE
Printing usage banner when mis-invoked

### DIFF
--- a/bin/mcmd
+++ b/bin/mcmd
@@ -42,8 +42,16 @@ optparse = OptionParser.new do |opts|
 end
 optparse.parse!
 
-raise "Error, need -r argument" if options[:range].nil? or options[:range].empty?
-raise "Error, need command to run" if ARGV.size.zero?
+if options[:range].nil? || options[:range].empty?
+  puts "#{$0}: Error, need -r argument"
+  puts optparse
+  exit 1
+end
+if ARGV.size.zero?
+  puts "#{$0}: Error, need command to run"
+  puts optparse
+  exit 1
+end
 
 m = MultipleCmd.new
 

--- a/bin/mcmd
+++ b/bin/mcmd
@@ -10,9 +10,12 @@ options = {
   :maxflight => 200,
   :timeout => 60,
   :global_timeout => 0,
+  :range => [],
 }
 
 optparse = OptionParser.new do |opts|
+  opts.banner = "Usage: mcmd [options] COMMAND"
+
   opts.on('-r', '--range RANGE', 'currently takes a CSV list') do |arg|
     options[:range] = arg 
   end

--- a/bin/mcmd
+++ b/bin/mcmd
@@ -37,6 +37,10 @@ optparse = OptionParser.new do |opts|
   opts.on('-d', '--debug', "Debug output") do |arg|
     options[:debug] = arg 
   end
+  opts.on_tail("-h", "--help", "Show this message") do
+    puts opts
+    exit
+  end
   # option to merge stdin/stdout into one buf? how should this work?
   # option to ignore as-we-go yield output - this is off by default now except for success/fail
 end


### PR DESCRIPTION
I'm sorta copying how `tail` does this.
