### PR TITLE
Adding tests for MultipleCmd

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org/'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,52 @@
+PATH
+  remote: .
+  specs:
+    mssh (0.0.10)
+      io-poll
+      json
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (3.5.1)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
+    coderay (1.1.0)
+    columnize (0.9.0)
+    debugger-linecache (1.2.0)
+    diff-lcs (1.2.5)
+    ffi (1.9.8)
+    io-poll (0.0.4)
+      ffi
+    json (1.8.2)
+    method_source (0.8.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.0.1)
+      byebug (~> 3.4)
+      pry (~> 0.10)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
+    slop (3.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mssh!
+  pry-byebug
+  rspec

--- a/lib/mcmd.rb
+++ b/lib/mcmd.rb
@@ -142,7 +142,7 @@ class MultipleCmd
   end
 
   def process_timeouts
-    now = Time.now.to_i
+    now = Time.now.to_f
     @subproc_by_pid.values.each do |p|
       if ((now - p.time_start) > self.perchild_timeout) and self.perchild_timeout > 0
         # expire this child process
@@ -164,7 +164,7 @@ class MultipleCmd
   end
 
   def run
-    @global_time_start = Time.now.to_i
+    @global_time_start = Time.now.to_f
     done = false
     while not done
       # start up as many as maxflight processes
@@ -227,7 +227,7 @@ class MultipleCmd
           # pid is now gone. remove from subproc_by_pid and
           # add to the processed commands list
           p = @subproc_by_pid[pid]
-          p.time_end = Time.now.to_i
+          p.time_end = Time.now.to_f
           p.retval = $?
           @subproc_by_pid.delete(pid)
           @processed_commands << p
@@ -257,7 +257,7 @@ class MultipleCmd::SubProc
 
   def initialize
     self.write_buf_position = 0
-    self.time_start = Time.now.to_i
+    self.time_start = Time.now.to_f
     self.stdout_buf = ""
     self.stderr_buf = ""
     self.terminated = false

--- a/mssh.gemspec
+++ b/mssh.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "json"
   s.add_dependency "io-poll"
+  s.add_development_dependency "pry-byebug"
+  s.add_development_dependency "rspec"
   s.default_executable = %q{mssh}
   s.executables = %W{ mssh mcmd }
 

--- a/spec/mcmd_spec.rb
+++ b/spec/mcmd_spec.rb
@@ -1,0 +1,41 @@
+require_relative '../lib/mcmd'
+
+# To run this test suite locally you must be able to ssh to localhost as the
+# current user without a passphrase.
+# Or you could help the maintainers out by figuring out a better way to mock.
+describe MultipleCmd do
+  Localhost = `hostname`
+
+  describe '.run' do
+    let(:targets) { ['localhost', 'localhost'] }
+    let(:command) { "hostname" }
+    let(:instance) do
+      MultipleCmd.new.tap do |m|
+        m.commands = targets.map { ["/bin/sh", "-c", command] }
+      end
+    end
+
+    subject(:run) { instance.run }
+
+    context 'a simple command on multiple hosts' do
+      it 'executes the command remotely' do
+        result = run
+        expect(result.size).to eq(2)
+        first, second = result
+
+        expect(first[:stdout_buf]).to eq(second[:stdout_buf])
+        expect(first[:stderr_buf]).to eq(second[:stderr_buf])
+        expect(first[:command]).to eq(second[:command])
+
+        expect(first[:stdout_buf]).to eq(Localhost)
+        expect(first[:stderr_buf]).to eq('')
+        expect(first[:retval].pid).to eq(first[:pid])
+        expect(first[:retval].exitstatus).to be(0)
+        expect(first[:write_buf_position]).to be(0)
+        expect(first[:command]).to eq(['/bin/sh', '-c', 'hostname'])
+        expect(first[:time_start]).to be_within(1.0).of(Time.now.to_i)
+        expect(first[:time_end]).to be_within(1.0).of(Time.now.to_i)
+      end
+    end
+  end
+end

--- a/spec/mcmd_spec.rb
+++ b/spec/mcmd_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../lib/mcmd'
+require 'timeout'
 
 # To run this test suite locally you must be able to ssh to localhost as the
 # current user without a passphrase.
@@ -9,11 +10,17 @@ describe MultipleCmd do
   describe '.run' do
     let(:targets) { ['localhost', 'localhost'] }
     let(:command) { "hostname" }
+    let(:global_timeout) { 0 }
+    let(:perchild_timeout) { 0 }
+    let(:verbose) { }
     let(:maxflight) { targets.size }
     let(:instance) do
       MultipleCmd.new.tap do |m|
-        m.commands = targets.map { ["/bin/sh", "-c", command] }
-        m.maxflight = maxflight
+        m.commands         = targets.map { ["/bin/sh", "-c", command] }
+        m.maxflight        = maxflight
+        m.verbose          = verbose
+        m.perchild_timeout = perchild_timeout
+        m.global_timeout   = global_timeout
       end
     end
 
@@ -42,19 +49,51 @@ describe MultipleCmd do
 
     context 'when maxflight is larger than the number of hosts' do
       let(:maxflight) { 1 }
-      let(:command) { 'sleep 1' }
+      let(:command) { 'sleep 0.2' }
 
       it 'serializes the executions' do
         result = run
         expect(result.size).to eq(2)
         first, second = result
         # The first one starts
-        expect(first[:time_start]).to be_within(0.1).of(Time.now.to_f - 2)
+        expect(first[:time_start]).to be_within(0.05).of(Time.now.to_f - 0.4)
         # And takes a second
-        expect(first[:time_end]).to be_within(0.1).of(Time.now.to_f - 1)
+        expect(first[:time_end]).to be_within(0.05).of(Time.now.to_f - 0.2)
         # And the second one starts right around the time the first one ends
-        expect(second[:time_start]).to be_within(0.1).of(first[:time_end])
-        expect(second[:time_end]).to be_within(0.1).of(Time.now.to_f)
+        expect(second[:time_start]).to be_within(0.05).of(first[:time_end])
+        expect(second[:time_end]).to be_within(0.05).of(Time.now.to_f)
+      end
+    end
+
+    context 'when perchild_timeout is set' do
+      let(:perchild_timeout) { 0.1 }
+      # 5 commands running serially
+      let(:maxflight) { 1 }
+      let(:targets) { ['localhost']*5 }
+      # which should take 50 seconds
+      let(:command) { 'sleep 10' }
+
+      it 'kills long-running children' do
+        # But only takes 0.1 * 5 or so
+        expect do
+          Timeout::timeout(0.7) { run }
+        end.to_not raise_error
+      end
+    end
+
+    context 'when global_timeout is set' do
+      let(:global_timeout) { 0.3 }
+      # 20 commands running serially
+      let(:maxflight) { 1 }
+      let(:targets) { ['localhost']*20 }
+      # which should take 0.1*20 = 1 second
+      let(:command) { 'sleep 0.1' }
+
+      it 'abandons subprocesses after the configured time' do
+        result = nil
+        expect { result = run  }.to_not raise_error
+        # Only about 3 of them ran before time ran out
+        expect(result.size).to be_within(1).of(3)
       end
     end
   end


### PR DESCRIPTION
* Adding initial specs
* Testing happy path
* Testing `maxflight` option
* Testing `perchild_timeout` option
* Testing `global_timeout` option

Note: the `global_timeout` was not yet implemented though the usage banner suggested it was. It's not implemented as of 502f31e02eafd8f4cd3857f91ac90b8c25a27b77