### PR TITLE
Factoring out redundancies between bin/mssh and bin/mcmd

### DIFF
--- a/bin/mcmd
+++ b/bin/mcmd
@@ -43,6 +43,9 @@ optparse = OptionParser.new do |opts|
   opts.on('-d', '--debug', "Debug output") do |arg|
     options[:debug] = arg 
   end
+  opts.on('--json', "Output results as JSON") do |arg|
+    options[:json_out] = arg
+  end
   # option to merge stdin/stdout into one buf? how should this work?
   # option to ignore as-we-go yield output - this is off by default now except for success/fail
 end
@@ -89,7 +92,12 @@ m.debug = options[:debug]
 
 result = m.run
 
-if options[:collapse]
+
+if (options[:json_out])
+  require 'json'
+  puts JSON.generate(result)
+
+elsif options[:collapse]
   # print a collapsed summary
   stdout_matches_success = Hash.new
   stdout_matches_failure = Hash.new

--- a/bin/mcmd
+++ b/bin/mcmd
@@ -1,128 +1,25 @@
 #!/usr/bin/env ruby
 
-require 'pp'
+require_relative '../lib/cli'
 
-$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + "/../lib"))
-require 'mcmd'
-
-require 'optparse'
-options = {
+cli = CommonCli.new({
+  # defaults
   :maxflight => 200,
   :timeout => 60,
   :global_timeout => 0,
-}
+})
 
-optparse = OptionParser.new do |opts|
-  opts.on('-r', '--range RANGE', 'currently takes a CSV list') do |arg|
-    options[:range] = arg 
+cli.extra_options = lambda do |parser, options|
+  parser.on('--noshell', "Don't invoke a shell. Args will be passed to exec verbatim ") do |arg|
+    options[:noshell] = arg
   end
-  opts.on('--hostlist x,y,z', Array, 'List of hostnames to execute on') do |arg|
-    options[:hostlist] = arg
-  end
-  opts.on('-f', '--file FILE', 'List of hostnames in a FILE use (/dev/stdin) for reading from stdin') do |arg|
-    options[:file] = arg
-  end
-  opts.on('-m', '--maxflight 50', 'How many subprocesses? 50 by default') do |arg|
-    options[:maxflight] = arg 
-  end
-  opts.on('-t', '--timeout 60', 'How many seconds may each individual process take? 0 for no timeout') do |arg|
-    options[:timeout] = arg 
-  end
-  opts.on('-g', '--global_timeout 600', 'How many seconds for the whole shebang 0 for no timeout') do |arg|
-    options[:global_timeout] = arg 
-  end
-  opts.on('--noshell', "Don't invoke a shell. Args will be passed to exec verbatim ") do |arg|
-    options[:noshell] = arg 
-  end
-  opts.on('-c', '--collapse', "Collapse similar output ") do |arg|
-    options[:collapse] = arg 
-  end
-  opts.on('-v', '--verbose', "Verbose output") do |arg|
-    options[:verbose] = arg 
-  end
-  opts.on('-d', '--debug', "Debug output") do |arg|
-    options[:debug] = arg 
-  end
-  opts.on('--json', "Output results as JSON") do |arg|
-    options[:json_out] = arg
-  end
-  # option to merge stdin/stdout into one buf? how should this work?
-  # option to ignore as-we-go yield output - this is off by default now except for success/fail
-end
-optparse.parse!
-
-## Get targets from -r or -f or --hostlist
-targets = []
-if (options[:range].nil? and options[:file].nil? and options[:hostlist].nil?)
-  raise "Error, need -r or -f or --hostlist option"
 end
 
-if (!options[:range].nil?)
-  require 'rangeclient'
-  range = Range::Client.new
-  targets.push *range.expand(options[:range])
-end
-if (!options[:file].nil?)
-  targets_fd = File.open(options[:file])
-  targets_fd.read.each_line { |x| targets << x.chomp }
-end
-if (!options[:hostlist].nil?)
-  targets.push *options[:hostlist]
+cli.parse ARGV
+
+result = cli.runcmd do |cmd, t|
+	if cli.options[:noshell] then [cmd] else ["/bin/sh", "-c"].push cmd end
 end
 
-raise "no targets specified. Check your -r, -f or --hostlist inputs" if targets.size.zero?
-raise "need command to run" if ARGV.size.zero?
-raise "too many arguments" if ARGV.size != 1
-
-m = MultipleCmd.new
-m.commands = targets.map { |t| ["/bin/sh", "-c"].push ARGV.map { |arg| arg.gsub('HOSTNAME', t)}.join " " }
-command_to_target = Hash.new
-targets.size.times do |i|
-  command_to_target[m.commands[i].object_id] = targets[i]
-end
-m.yield_startcmd = lambda { |p| puts "#{command_to_target[p.command.object_id]}: starting" } if options[:verbose]
-m.yield_wait = lambda { |p| puts "#{p.success? ? 'SUCCESS' : 'FAILURE'} #{command_to_target[p.command.object_id]}: '#{p.stdout_buf}'" }
-# m.yield_proc_timeout = lambda { |p| puts "am killing #{p.inspect}"}
-
-m.perchild_timeout = options[:timeout].to_i
-m.global_timeout = options[:global_timeout].to_i
-m.maxflight = options[:maxflight].to_i
-m.verbose = options[:verbose]
-m.debug = options[:debug]
-
-result = m.run
-
-
-if (options[:json_out])
-  require 'json'
-  puts JSON.generate(result)
-
-elsif options[:collapse]
-  # print a collapsed summary
-  stdout_matches_success = Hash.new
-  stdout_matches_failure = Hash.new
-  result.each do |r|
-    if r[:retval].success?
-      stdout_matches_success[r[:stdout_buf]] = [] if stdout_matches_success[r[:stdout_buf]].nil?
-      stdout_matches_success[r[:stdout_buf]] << command_to_target[r[:command].object_id]
-    else
-      stdout_matches_failure[r[:stdout_buf]] = [] if stdout_matches_failure[r[:stdout_buf]].nil?
-      stdout_matches_failure[r[:stdout_buf]] << command_to_target[r[:command].object_id]
-    end
-  end
-  # output => [targets ...]
-  stdout_matches_success.each_pair do |k,v|
-    puts "SUCCESS: #{v.join ','}: #{k}"
-  end
-  stdout_matches_failure.each_pair do |k,v|
-    puts "FAILURE: #{v.join ','}: #{k}"
-  end
-else
-  # we already printed while in-flight; do nothing
-    # not collapse, print one per host
-#  result.each do |r|
-#    target = command_to_target[r[:command].object_id]
-#    puts "#{target}: '#{r[:stdout_buf].chomp}'\n"
-#  end
-end
+cli.output result
 

--- a/bin/mcmd
+++ b/bin/mcmd
@@ -16,6 +16,12 @@ optparse = OptionParser.new do |opts|
   opts.on('-r', '--range RANGE', 'currently takes a CSV list') do |arg|
     options[:range] = arg 
   end
+  opts.on('--hostlist x,y,z', Array, 'List of hostnames to execute on') do |arg|
+    options[:hostlist] = arg
+  end
+  opts.on('-f', '--file FILE', 'List of hostnames in a FILE use (/dev/stdin) for reading from stdin') do |arg|
+    options[:file] = arg
+  end
   opts.on('-m', '--maxflight 50', 'How many subprocesses? 50 by default') do |arg|
     options[:maxflight] = arg 
   end
@@ -42,13 +48,30 @@ optparse = OptionParser.new do |opts|
 end
 optparse.parse!
 
-raise "Error, need -r argument" if options[:range].nil? or options[:range].empty?
-raise "Error, need command to run" if ARGV.size.zero?
+## Get targets from -r or -f or --hostlist
+targets = []
+if (options[:range].nil? and options[:file].nil? and options[:hostlist].nil?)
+  raise "Error, need -r or -f or --hostlist option"
+end
+
+if (!options[:range].nil?)
+  require 'rangeclient'
+  range = Range::Client.new
+  targets.push *range.expand(options[:range])
+end
+if (!options[:file].nil?)
+  targets_fd = File.open(options[:file])
+  targets_fd.read.each_line { |x| targets << x.chomp }
+end
+if (!options[:hostlist].nil?)
+  targets.push *options[:hostlist]
+end
+
+raise "no targets specified. Check your -r, -f or --hostlist inputs" if targets.size.zero?
+raise "need command to run" if ARGV.size.zero?
+raise "too many arguments" if ARGV.size != 1
 
 m = MultipleCmd.new
-
-targets = options[:range].split ","
-
 m.commands = targets.map { |t| ["/bin/sh", "-c"].push ARGV.map { |arg| arg.gsub('HOSTNAME', t)}.join " " }
 command_to_target = Hash.new
 targets.size.times do |i|

--- a/bin/mssh
+++ b/bin/mssh
@@ -96,7 +96,7 @@ m.debug = options[:debug]
 
 result = m.run
 
-if (options[:collapse] and options[:range])
+if (options[:collapse])
   # print a collapsed summary
   out_matches = Hash.new
   result.each do |r|
@@ -108,7 +108,7 @@ if (options[:collapse] and options[:range])
   end
   # output => [targets ...]
   out_matches.each_pair do |k,v|
-    hosts = range.compress v
+    hosts = if options[:range] then range.compress v else v.join ',' end
     puts "#{hosts}: '#{k.chomp}'"
   end
 else

--- a/bin/mssh
+++ b/bin/mssh
@@ -29,4 +29,3 @@ result = cli.runcmd do |command, target|
 end
 
 cli.output result
-

--- a/bin/mssh
+++ b/bin/mssh
@@ -1,133 +1,32 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
-require 'rubygems'
-require 'pp'
-require 'mcmd'
+require_relative '../lib/cli'
 
-require 'optparse'
-require 'ostruct'
-options = {
+cli = CommonCli.new({
+  # defaults
   :maxflight => 50,
   :timeout => 60,
   :global_timeout => 600,
-}
-optparse = OptionParser.new do |opts|
-  opts.on('-r', '--range RANGE', 'Requires a configured Range::Client. Use --hostlist if you do not use range') do |arg|
-    options[:range] = arg 
-  end
-  opts.on('--hostlist x,y,z', Array, 'List of hostnames to execute on') do |arg|
-    options[:hostlist] = arg 
-  end
-  opts.on('-f', '--file FILE', 'List of hostnames in a FILE use (/dev/stdin) for reading from stdin') do |arg|
-    options[:file] = arg 
-  end
-  opts.on('-m', '--maxflight 50', 'How many subprocesses? 50 by default') do |arg|
-    options[:maxflight] = arg 
-  end
-  opts.on('-t', '--timeout 60', 'How many seconds may each individual process take? 0 for no timeout') do |arg|
-    options[:timeout] = arg 
-  end
-  opts.on('-g', '--global_timeout 600', 'How many seconds for the whole shebang 0 for no timeout') do |arg|
-    options[:global_timeout] = arg 
-  end
-  opts.on('-c', '--collapse', "Collapse similar output ") do |arg|
-    options[:collapse] = arg 
-  end
-  opts.on('-v', '--verbose', "verbose ") do |arg|
-    options[:verbose] = arg 
-  end
-  opts.on('-d', '--debug', "Debug output") do |arg|
-    options[:debug] = arg 
-  end
-  opts.on('--sshopt OPT',  "ssh options, default [-2, -oBatchMode=yes, -A]. Can be used multiple times.") do |arg|
+  :sshcmd => "/usr/bin/ssh",
+  :sshopt => ["-2", "-oBatchMode=yes", "-A"]
+})
+
+## Extra options for the SSH version
+cli.extra_options = lambda do |parser, options|
+  parser.on('--sshopt OPT',  "ssh options, default [-2, -oBatchMode=yes, -A]. Can be used multiple times.") do |arg|
     options[:sshopt] ||= []
     options[:sshopt] << arg
   end
-  opts.on('--sshcmd BINARY', "Path to the ssh binary") do |arg|
+  parser.on('--sshcmd BINARY', "Path to the ssh binary (default /usr/bin/ssh)") do |arg|
     options[:sshcmd] = arg
   end
-  opts.on('--json', "Output results as JSON") do |arg|
-    options[:json_out] = arg
-  end
-  # option to merge stdin/stdout into one buf?
-  # option to ignore as-we-go yield output
-end
-optparse.parse!
-
-# default options
-options[:sshopt] ||= ["-2", "-oBatchMode=yes", "-A"]
-options[:sshcmd] = "/usr/bin/ssh"
-
-targets = []
-if (options[:range].nil? and options[:file].nil? and options[:hostlist].nil?)
-  raise "Error, need -r or -f or --hostlist option"
 end
 
-if (!options[:range].nil?)
-  require 'rangeclient'
-  range = Range::Client.new
-  targets.push *range.expand(options[:range])
-end
-if (!options[:file].nil?)
-  targets_fd = File.open(options[:file])
-  targets_fd.read.each_line { |x| targets << x.chomp }
-end
-if (!options[:hostlist].nil?)
-  targets.push *options[:hostlist]
+cli.parse ARGV
+
+result = cli.runcmd do |command, target|
+  [cli.options[:sshcmd], *cli.options[:sshopt]].push target, command
 end
 
-raise "no targets specified. Check your -r, -f or --hostlist inputs" if targets.size.zero?
-raise "need command to run" if ARGV.size.zero?
-raise "too many arguments" if ARGV.size != 1
+cli.output result
 
-m = MultipleCmd.new
-m.commands = targets.map { |t| [options[:sshcmd], *options[:sshopt] ].push t, ARGV.first }
-command_to_target = Hash.new
-targets.size.times do |i|
-  command_to_target[m.commands[i].object_id] = targets[i]
-end
-m.yield_startcmd = lambda { |p| puts "#{command_to_target[p.command.object_id]}: starting" } if options[:verbose]
-m.yield_wait = lambda { |p| puts "#{command_to_target[p.command.object_id]}: finished" } if options[:verbose]
-
-m.perchild_timeout = options[:timeout].to_i
-m.global_timeout = options[:global_timeout].to_i
-m.maxflight = options[:maxflight].to_i
-m.verbose = options[:verbose]
-m.debug = options[:debug]
-
-result = m.run
-
-if (options[:json_out])
-  require 'json'
-  puts JSON.generate(result)
-
-elsif (options[:collapse])
-  # print a collapsed summary
-  out_matches = Hash.new
-  result.each do |r|
-    out = "" 
-    out += r[:stdout_buf].chomp if(!r[:stdout_buf].nil?)
-    out += r[:stderr_buf].chomp if(!r[:stderr_buf].nil?)
-    out_matches[out] = [] if out_matches[out].nil?
-    out_matches[out] << command_to_target[r[:command].object_id]
-  end
-  # output => [targets ...]
-  out_matches.each_pair do |k,v|
-    hosts = if options[:range] then range.compress v else v.join ',' end
-    puts "#{hosts}: '#{k.chomp}'"
-  end
-else
-  # not collapse, print one per host
-  result.each do |r|
-    target = command_to_target[r[:command].object_id]
-    out = "" 
-    out += r[:stdout_buf].chomp if(!r[:stdout_buf].nil?)
-    out += r[:stderr_buf].chomp if(!r[:stderr_buf].nil?)
-    if (r[:retval] == 0 )
-        puts "#{target}:SUCCESS: #{out}\n"
-    else
-        exit_code = r[:retval].exitstatus.to_s if(!r[:retval].nil?)
-        puts "#{target}:FAILURE[#{exit_code}]: #{out}\n"
-    end
-  end
-end

--- a/bin/mssh
+++ b/bin/mssh
@@ -46,6 +46,9 @@ optparse = OptionParser.new do |opts|
   opts.on('--sshcmd BINARY', "Path to the ssh binary") do |arg|
     options[:sshcmd] = arg
   end
+  opts.on('--json', "Output results as JSON") do |arg|
+    options[:json_out] = arg
+  end
   # option to merge stdin/stdout into one buf?
   # option to ignore as-we-go yield output
 end
@@ -77,8 +80,6 @@ raise "no targets specified. Check your -r, -f or --hostlist inputs" if targets.
 raise "need command to run" if ARGV.size.zero?
 raise "too many arguments" if ARGV.size != 1
 
-
-
 m = MultipleCmd.new
 m.commands = targets.map { |t| [options[:sshcmd], *options[:sshopt] ].push t, ARGV.first }
 command_to_target = Hash.new
@@ -96,7 +97,11 @@ m.debug = options[:debug]
 
 result = m.run
 
-if (options[:collapse])
+if (options[:json_out])
+  require 'json'
+  puts JSON.generate(result)
+
+elsif (options[:collapse])
   # print a collapsed summary
   out_matches = Hash.new
   result.each do |r|

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -1,0 +1,180 @@
+require 'optparse'
+require_relative './mcmd'
+##
+# Implements what is shared
+# between mssh and mcmd.
+class CommonCli
+  attr_accessor :options, :result, :command_to_target, :targets
+  attr_writer   :extra_options
+
+  def initialize(defaults)
+    @options = defaults
+    @options[:hostname_token] = 'HOSTNAME'
+  end
+
+  ##
+  # Parses a list of arguments, and yells
+  # at us if any are wrong.
+  def parse(argv)
+
+    @defs = Hash[@options.map{|k,v| [k, " (default: #{v})"] } ]
+
+    optparse = OptionParser.new do |opts|
+      opts.on('-r', '--range RANGE', 'currently takes a CSV list' + @defs[:range].to_s ) do |arg|
+        @options[:range] = arg
+      end
+      opts.on('--hostlist x,y,z', Array, 'List of hostnames to execute on' + @defs[:hostlist].to_s) do |arg|
+        @options[:hostlist] = arg
+      end
+      opts.on('-f', '--file FILE', 'List of hostnames in a FILE use (/dev/stdin) for reading from stdin' + @defs[:file].to_s) do |arg|
+        @options[:file] = arg
+      end
+      opts.on('-m', '--maxflight 200', 'How many subprocesses? 50 by default' + @defs[:maxflight].to_s) do |arg|
+        @options[:maxflight] = arg
+      end
+      opts.on('-t', '--timeout 60', 'How many seconds may each individual process take? 0 for no timeout' + @defs[:timeout].to_s) do |arg|
+        @options[:timeout] = arg
+      end
+      opts.on('-g', '--global_timeout 0', 'How many seconds for the whole shebang 0 for no timeout' + @defs[:global_timeout].to_s) do |arg|
+        @options[:global_timeout] = arg
+      end
+      opts.on('-c', '--collapse', "Collapse similar output " + @defs[:collapse].to_s) do |arg|
+        @options[:collapse] = arg
+      end
+      opts.on('-v', '--verbose', "Verbose output" + @defs[:verbose].to_s) do |arg|
+        @options[:verbose] = arg
+      end
+      opts.on('-d', '--debug', "Debug output" + @defs[:debug].to_s) do |arg|
+        @options[:debug] = arg
+      end
+      opts.on('--json', "Output results as JSON" + @defs[:json_out].to_s) do |arg|
+        @options[:json_out] = arg
+      end
+      opts.on('--hntoken HOSTNAME', "Token used for HOSTNAME substitution" + @defs[:hostname_token].to_s) do |arg|
+        @options[:hostname_token] = arg
+      end
+
+      @extra_options.call(opts, @options) if !@extra_options.nil?
+
+      # option to merge stdin/stdout into one buf? how should this work?
+      # option to ignore as-we-go yield output - this is off by default now except for success/fail
+    end
+
+    optparse.parse! argv
+
+    ## Get targets from -r or -f or --hostlist
+    @targets = []
+    if (options[:range].nil? and options[:file].nil? and options[:hostlist].nil?)
+      raise "Error, need -r or -f or --hostlist option"
+    end
+
+    if (!options[:range].nil?)
+      require 'rangeclient'
+      range = Range::Client.new
+      @targets.push *range.expand(options[:range])
+    end
+
+    if (!options[:file].nil?)
+      targets_fd = File.open(options[:file])
+      targets_fd.read.each_line { |x| @targets << x.chomp }
+    end
+
+    if (!options[:hostlist].nil?)
+      @targets.push *options[:hostlist]
+    end
+
+    raise "no targets specified. Check your -r, -f or --hostlist inputs" if @targets.size.zero?
+    raise "need command to run"                                          if argv.size.zero?
+    raise "too many arguments"                                           if argv.size != 1
+
+    @command = argv.first
+
+  end
+
+  def runcmd
+
+    m = MultipleCmd.new
+
+    # We let the caller build the command
+    m.commands = @targets.map do |t|
+      yield(@command.gsub(@options[:hostname_token], t), t)
+    end
+
+    @command_to_target = Hash.new
+    @targets.size.times do |i|
+      @command_to_target[m.commands[i].object_id] = @targets[i]
+    end
+
+    m.yield_startcmd = lambda { |p| puts "#{@command_to_target[p.command.object_id]}: starting" } if @options[:verbose]
+    m.yield_wait     = lambda { |p| puts "#{p.success? ? 'SUCCESS' : 'FAILURE'} #{@command_to_target[p.command.object_id]}: '#{p.stdout_buf}'" } if @options[:verbose]
+    # todo, from mssh m.yield_wait = lambda { |p| puts "#{@command_to_target[p.command.object_id]}: finished" } if @options[:verbose]
+
+    # was commented out in mcmd already: m.yield_proc_timeout = lambda { |p| puts "am killing #{p.inspect}"}
+
+    m.perchild_timeout = @options[:timeout].to_i
+    m.global_timeout   = @options[:global_timeout].to_i
+    m.maxflight        = @options[:maxflight].to_i
+    m.verbose          = @options[:verbose]
+    m.debug            = @options[:debug]
+
+    return m.run
+  end
+
+  def output result
+
+    ## Print as JSON array
+    if (@options[:json_out])
+      require 'json'
+      puts JSON.generate(result)
+      return
+    end
+
+    # Concat stdout / stderr -> :all_buf
+    result.each do |r|
+      r[:all_buf] = ""
+      r[:all_buf] += r[:stdout_buf].chomp if(!r[:stdout_buf].nil?)
+      r[:all_buf] += r[:stderr_buf].chomp if(!r[:stderr_buf].nil?)
+    end
+
+    ## Collapse similar results
+    if @options[:collapse]
+      stdout_matches_success = Hash.new
+      stdout_matches_failure = Hash.new
+      result.each do |r|
+
+        if r[:retval].success?
+          stdout_matches_success[r[:all_buf]] = [] if stdout_matches_success[r[:all_buf]].nil?
+          stdout_matches_success[r[:all_buf]] << @command_to_target[r[:command].object_id]
+        else
+          stdout_matches_failure[r[:all_buf]] = [] if stdout_matches_failure[r[:all_buf]].nil?
+          stdout_matches_failure[r[:all_buf]] << @command_to_target[r[:command].object_id]
+        end
+      end
+      require 'rangeclient'
+      range = Range::Client.new
+      # output => [targets ...]
+      stdout_matches_success.each_pair do |k,v|
+        hosts = if @options[:range] then range.compress v else v.join ',' end
+        # puts "#{hosts}: '#{k.chomp}'"
+        puts "SUCCESS: #{hosts}: #{k}"
+      end
+      stdout_matches_failure.each_pair do |k,v|
+        hosts = if @options[:range] then range.compress v else v.join ',' end
+        puts "FAILURE: #{hosts}: #{k}"
+      end
+
+    ## Dont collapse similar resutls
+    else
+      result.each do |r|
+        target = @command_to_target[r[:command].object_id]
+        if (r[:retval].success?)
+            puts "#{target}:SUCCESS: #{r[:all_buf]}\n"
+        else
+            exit_code = r[:retval].exitstatus.to_s if(!r[:retval].nil?)
+            puts "#{target}:FAILURE[#{exit_code}]: #{r[:all_buf]}\n"
+        end
+      end
+    end
+
+  end
+end

--- a/mssh.gemspec
+++ b/mssh.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "mssh"
-  s.version     = "0.0.11"
+  s.version     = "0.0.12"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Evan Miller"]
   s.email       = ["github@squareup.com"]


### PR DESCRIPTION
- factors out redundancies between `bin/mssh` and `bin/mcmd` to `lib/cli.rb`
- mcmd doesn't print individual results when run with `-c`
- adds support for the HOSTNAME keyword on mssh
- also mssh, mcmd can both now choose HOSTNAME token with the `--hntoken` argument
- both mssh and mcmd now distinguish exit 0 and report the exit code if != 0
- Implements the `--noshell` option on mcmd

\+ All the stuff in v0.0.12 because it hasn't been merged to master