### PR TITLE
Remove io/poll. This breaks compatibility with Ruby 1.8, which we no …

### DIFF
--- a/lib/mcmd.rb
+++ b/lib/mcmd.rb
@@ -1,9 +1,5 @@
 #!/usr/bin/ruby
 
-require 'pp'
-require 'rubygems'
-require 'io/poll'
-
 class MultipleCmd
 
   attr_accessor :global_timeout, :maxflight, :perchild_timeout, :commands
@@ -136,7 +132,7 @@ class MultipleCmd
     write_fds = subproc_by_pid.values.select {|x| not x.stdin_fd.nil? and not x.terminated}.map {|x| x.stdin_fd}
     read_fds = subproc_by_pid.values.select {|x| not x.terminated}.map {|x| [x.stdout_fd, x.stderr_fd].select {|x| not x.nil? } }.flatten
 
-    read_fds, write_fds, err_fds = IO.select_using_poll(read_fds, write_fds, nil, self.poll_period)
+    read_fds, write_fds, err_fds = IO.select(read_fds, write_fds, nil, self.poll_period)
 
     self.process_read_fds(read_fds) unless read_fds.nil?
     self.process_write_fds(write_fds) unless write_fds.nil?
@@ -244,7 +240,7 @@ class MultipleCmd
     # We may have waited on a child before reading all its output. Collect those missing bits. No blocking.
     if not just_reaped.empty?
       read_fds = just_reaped.select {|x| not x.terminated}.map {|x| [x.stdout_fd, x.stderr_fd].select {|x| not x.nil? } }.flatten
-      read_fds, write_fds, err_fds = IO.select_using_poll(read_fds, nil, nil, 0)
+      read_fds, write_fds, err_fds = IO.select(read_fds, nil, nil, 0)
       self.process_read_fds(read_fds) unless read_fds.nil?
     end
     just_reaped.each do |p|

--- a/mssh.gemspec
+++ b/mssh.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
 
   s.add_dependency "json"
-  s.add_dependency "io-poll"
   s.add_development_dependency "rspec"
 end
 


### PR DESCRIPTION
…longer support in this gem.